### PR TITLE
Update fs-path

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mocha": "^2.4.5"
   },
   "dependencies": {
-    "fs-path": "0.0.22",
+    "fs-path": "0.0.25",
     "glob": "^7.0.3"
   }
 }


### PR DESCRIPTION
Update to include security fix https://github.com/pillys/fs-path/pull/5

(Note that https://www.npmjs.com/advisories/661 still incorrectly reports version 0.0.25 as vulnerable.)